### PR TITLE
Feature implementation from commits 7cbcffc..621c0c7

### DIFF
--- a/docs/integrations/integrations.mdx
+++ b/docs/integrations/integrations.mdx
@@ -6,10 +6,6 @@ icon: "link"
 
 MindsDB integrates with numerous data sources and popular AI/ML frameworks to seamlessly bring data and AI together.
 
-<p align="center">
-  <img src="/assets/diagram.png"/>
-</p>
-
 [Data sources](/integrations/data-overview) are all the data sources that you can conect to MindsDB, including traditional databases and data that is behind APIs. It is important that MindsDB does no ETL pipelines. When you query a data source MindsDB forwards this query in real-time to the original data source. MindsDB is very good at translating SQL to any other query dialect.
 
 <Tip>

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2252,9 +2252,10 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = "MindsDB"
 __package_name__ = "mindsdb"
-__version__ = "25.6.2.0"
+__version__ = "25.6.3.0"
 __description__ = "MindsDB's AI SQL Server enables developers to build AI tools that need access to real-time data to perform their tasks"
 __email__ = "jorge@mindsdb.com"
 __author__ = "MindsDB Inc"

--- a/mindsdb/__about__.py
+++ b/mindsdb/__about__.py
@@ -1,6 +1,6 @@
 __title__ = "MindsDB"
 __package_name__ = "mindsdb"
-__version__ = "25.6.3.0"
+__version__ = "25.6.3.1"
 __description__ = "MindsDB's AI SQL Server enables developers to build AI tools that need access to real-time data to perform their tasks"
 __email__ = "jorge@mindsdb.com"
 __author__ = "MindsDB Inc"

--- a/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/information_schema_datanode.py
@@ -15,12 +15,38 @@ from mindsdb.integrations.libs.response import INF_SCHEMA_COLUMNS_NAMES
 from mindsdb.utilities import log
 
 from .system_tables import (
-    SchemataTable, TablesTable, ColumnsTable, EventsTable, RoutinesTable,
-    PluginsTable, EnginesTable, KeyColumnUsageTable, StatisticsTable,
-    CharacterSetsTable, CollationsTable)
+    SchemataTable,
+    TablesTable,
+    MetaTablesTable,
+    ColumnsTable,
+    MetaColumnsTable,
+    EventsTable,
+    RoutinesTable,
+    PluginsTable,
+    EnginesTable,
+    MetaTableConstraintsTable,
+    KeyColumnUsageTable,
+    MetaColumnUsageTable,
+    StatisticsTable,
+    MetaColumnStatisticsTable,
+    CharacterSetsTable,
+    CollationsTable,
+    MetaHandlerInfoTable,
+)
 from .mindsdb_tables import (
-    ModelsTable, DatabasesTable, MLEnginesTable, HandlersTable, JobsTable, QueriesTable,
-    ChatbotsTable, KBTable, SkillsTable, AgentsTable, ViewsTable, TriggersTable)
+    ModelsTable,
+    DatabasesTable,
+    MLEnginesTable,
+    HandlersTable,
+    JobsTable,
+    QueriesTable,
+    ChatbotsTable,
+    KBTable,
+    SkillsTable,
+    AgentsTable,
+    ViewsTable,
+    TriggersTable,
+)
 
 from mindsdb.api.executor.datahub.classes.tables_row import TablesRow
 
@@ -32,12 +58,35 @@ class InformationSchemaDataNode(DataNode):
     type = "INFORMATION_SCHEMA"
 
     tables_list = [
-        SchemataTable, TablesTable, ColumnsTable, EventsTable, RoutinesTable,
-        PluginsTable, EnginesTable, KeyColumnUsageTable, StatisticsTable,
-        CharacterSetsTable, CollationsTable,
-        ModelsTable, DatabasesTable, MLEnginesTable, HandlersTable, JobsTable,
-        ChatbotsTable, KBTable, SkillsTable, AgentsTable, ViewsTable, TriggersTable,
-        QueriesTable
+        SchemataTable,
+        TablesTable,
+        MetaTablesTable,
+        ColumnsTable,
+        MetaColumnsTable,
+        EventsTable,
+        RoutinesTable,
+        PluginsTable,
+        EnginesTable,
+        MetaTableConstraintsTable,
+        KeyColumnUsageTable,
+        MetaColumnUsageTable,
+        StatisticsTable,
+        MetaColumnStatisticsTable,
+        CharacterSetsTable,
+        CollationsTable,
+        ModelsTable,
+        DatabasesTable,
+        MLEnginesTable,
+        HandlersTable,
+        JobsTable,
+        ChatbotsTable,
+        KBTable,
+        SkillsTable,
+        AgentsTable,
+        ViewsTable,
+        TriggersTable,
+        QueriesTable,
+        MetaHandlerInfoTable,
     ]
 
     def __init__(self, session):
@@ -46,9 +95,7 @@ class InformationSchemaDataNode(DataNode):
         self.project_controller = ProjectController()
         self.database_controller = session.database_controller
 
-        self.persis_datanodes = {
-            'log': self.database_controller.logs_db_controller
-        }
+        self.persis_datanodes = {"log": self.database_controller.logs_db_controller}
 
         databases = self.database_controller.get_dict()
         if "files" in databases:
@@ -69,15 +116,13 @@ class InformationSchemaDataNode(DataNode):
         if name_lower == "information_schema":
             return self
 
-        if name_lower == 'log':
-            return self.database_controller.get_system_db('log')
+        if name_lower == "log":
+            return self.database_controller.get_system_db("log")
 
         if name_lower in self.persis_datanodes:
             return self.persis_datanodes[name_lower]
 
-        existing_databases_meta = (
-            self.database_controller.get_dict()
-        )  # filter_type='project'
+        existing_databases_meta = self.database_controller.get_dict()  # filter_type='project'
         database_name = None
         for key in existing_databases_meta:
             if key.lower() == name_lower:
@@ -130,9 +175,7 @@ class InformationSchemaDataNode(DataNode):
         """
         table_name = table_name.upper()
         if table_name not in self.tables:
-            raise exc.TableNotExistError(
-                f"Table information_schema.{table_name} does not exists"
-            )
+            raise exc.TableNotExistError(f"Table information_schema.{table_name} does not exists")
         table_columns_names = self.tables[table_name].columns
         df = pd.DataFrame([[table_columns_names]], columns=[INF_SCHEMA_COLUMNS_NAMES.COLUMN_NAME])
         for column_name in astuple(INF_SCHEMA_COLUMNS_NAMES):
@@ -153,9 +196,7 @@ class InformationSchemaDataNode(DataNode):
         """
         table_name = table_name.upper()
         if table_name not in self.tables:
-            raise exc.TableNotExistError(
-                f"Table information_schema.{table_name} does not exists"
-            )
+            raise exc.TableNotExistError(f"Table information_schema.{table_name} does not exists")
         return self.tables[table_name].columns
 
     def get_integrations_names(self):
@@ -168,25 +209,16 @@ class InformationSchemaDataNode(DataNode):
         return [x.lower() for x in projects]
 
     def get_tables(self):
-        return [
-            TablesRow(TABLE_NAME=name)
-            for name in self.tables.keys()
-        ]
+        return [TablesRow(TABLE_NAME=name) for name in self.tables.keys()]
 
     def get_tree_tables(self):
-        return {
-            name: table
-            for name, table in self.tables.items()
-            if table.visible
-        }
+        return {name: table for name, table in self.tables.items() if table.visible}
 
     def query(self, query: ASTNode, session=None) -> DataHubResponse:
         query_tables = [x[1] for x in get_query_tables(query)]
 
         if len(query_tables) != 1:
-            raise exc.BadTableError(
-                f"Only one table can be used in query to information_schema: {query}"
-            )
+            raise exc.BadTableError(f"Only one table can be used in query to information_schema: {query}")
 
         table_name = query_tables[0].upper()
 
@@ -195,7 +227,7 @@ class InformationSchemaDataNode(DataNode):
 
         tbl = self.tables[table_name]
 
-        if hasattr(tbl, 'get_data'):
+        if hasattr(tbl, "get_data"):
             dataframe = tbl.get_data(query=query, inf_schema=self, session=self.session)
         else:
             dataframe = self._get_empty_table(tbl)
@@ -203,11 +235,7 @@ class InformationSchemaDataNode(DataNode):
 
         columns_info = [{"name": k, "type": v} for k, v in data.dtypes.items()]
 
-        return DataHubResponse(
-            data_frame=data,
-            columns=columns_info,
-            affected_rows=0
-        )
+        return DataHubResponse(data_frame=data, columns=columns_info, affected_rows=0)
 
     def _get_empty_table(self, table):
         columns = table.columns

--- a/mindsdb/api/executor/datahub/datanodes/project_datanode.py
+++ b/mindsdb/api/executor/datahub/datanodes/project_datanode.py
@@ -154,7 +154,7 @@ class ProjectDataNode(DataNode):
 
                 return DataHubResponse(data_frame=df, columns=columns_info)
 
-            raise EntityNotExistsError(f"Can't select from {query_table} in project")
+            raise EntityNotExistsError(f"Can't select from <{query_table}> in project")
         else:
             raise NotImplementedError(f"Query not supported {query}")
 

--- a/mindsdb/api/executor/datahub/datanodes/system_tables.py
+++ b/mindsdb/api/executor/datahub/datanodes/system_tables.py
@@ -1,4 +1,4 @@
-from typing import Optional, Literal
+from typing import Optional, List, Literal
 from dataclasses import dataclass, fields
 
 import pandas as pd
@@ -8,6 +8,7 @@ from mindsdb.utilities import log
 from mindsdb.utilities.config import config
 from mindsdb.integrations.utilities.sql_utils import extract_comparison_conditions
 from mindsdb.integrations.libs.response import INF_SCHEMA_COLUMNS_NAMES
+from mindsdb.interfaces.data_catalog.data_catalog_reader import DataCatalogReader
 from mindsdb.api.mysql.mysql_proxy.libs.constants.mysql import MYSQL_DATA_TYPE, MYSQL_DATA_TYPE_COLUMNS_DEFAULT
 from mindsdb.api.executor.datahub.classes.tables_row import TABLES_ROW_TYPE, TablesRow
 
@@ -500,6 +501,318 @@ class CollationsTable(Table):
             ["utf8_general_ci", "utf8", 33, "Yes", "Yes", 1, "PAD SPACE"],
             ["latin1_swedish_ci", "latin1", 8, "Yes", "Yes", 1, "PAD SPACE"],
         ]
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+# Data Catalog tables
+# TODO: Should these be placed in a separate schema?
+
+
+def _get_records_from_data_catalog(databases: List, tables: Optional[List[str]] = None) -> List:
+    """Get records from the data catalog based on the specified databases and tables."""
+    # TODO: Should we allow to query all databases?
+    if not databases:
+        raise ValueError("At least one database must be specified in the query.")
+
+    records = []
+    for database in databases:
+        data_catalog_reader = DataCatalogReader(database_name=database, table_names=tables)
+        records.extend(data_catalog_reader.read_metadata_as_records())
+
+    return records
+
+
+# TODO: Combine with existing 'TablesTable'?
+class MetaTablesTable(Table):
+    name = "META_TABLES"
+
+    columns = ["TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "TABLE_TYPE", "TABLE_DESCRIPTION", "ROW_COUNT"]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, _ = _get_scope(query)
+
+        records = _get_records_from_data_catalog(databases)
+
+        data = []
+        for record in records:
+            item = {
+                "TABLE_CATALOG": "def",
+                "TABLE_SCHEMA": record.integration.name,
+                "TABLE_NAME": record.name,
+                "TABLE_TYPE": record.type,
+                "TABLE_DESCRIPTION": record.description or "",
+                "ROW_COUNT": record.row_count,
+            }
+            data.append(item)
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+# TODO: Combine with existing 'ColumnsTable'?
+class MetaColumnsTable(Table):
+    name = "META_COLUMNS"
+
+    columns = [
+        "TABLE_CATALOG",
+        "TABLE_SCHEMA",
+        "TABLE_NAME",
+        "COLUMN_NAME",
+        "DATA_TYPE",
+        "COLUMN_DESCRIPTION",
+        "COLUMN_DEFAULT",
+        "IS_NULLABLE",
+    ]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, tables = _get_scope(query)
+
+        records = _get_records_from_data_catalog(databases, tables)
+
+        data = []
+        for record in records:
+            database_name = record.integration.name
+            table_name = record.name
+            columns = record.meta_columns
+
+            for column in columns:
+                item = {
+                    "TABLE_CATALOG": "def",
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "COLUMN_NAME": column.name,
+                    "DATA_TYPE": column.data_type,
+                    "COLUMN_DESCRIPTION": column.description or "",
+                    "COLUMN_DEFAULT": column.default_value,
+                    "IS_NULLABLE": "YES" if column.is_nullable else "NO",
+                }
+                data.append(item)
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+class MetaColumnStatisticsTable(Table):
+    name = "META_COLUMN_STATISTICS"
+    columns = [
+        "TABLE_SCHEMA",
+        "TABLE_NAME",
+        "COLUMN_NAME",
+        "MOST_COMMON_VALS",
+        "MOST_COMMON_FREQS",
+        "NULL_FRAC",
+        "N_DISTINCT",
+        "MIN_VALUE",
+        "MAX_VALUE",
+    ]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, tables = _get_scope(query)
+
+        records = _get_records_from_data_catalog(databases, tables)
+
+        data = []
+        for record in records:
+            database_name = record.integration.name
+            table_name = record.name
+            columns = record.meta_columns
+
+            for column in columns:
+                column_statistics = column.meta_column_statistics[0]
+
+                item = {
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "COLUMN_NAME": column.name,
+                }
+
+                if column_statistics:
+                    item.update(
+                        {
+                            "MOST_COMMON_VALS": column_statistics.most_common_values,
+                            "MOST_COMMON_FREQS": column_statistics.most_common_frequencies,
+                            "NULL_FRAC": column_statistics.null_percentage,
+                            "N_DISTINCT": column_statistics.distinct_values_count,
+                            "MIN_VALUE": column_statistics.minimum_value,
+                            "MAX_VALUE": column_statistics.maximum_value,
+                        }
+                    )
+
+                data.append(item)
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+class MetaTableConstraintsTable(Table):
+    name = "META_TABLE_CONSTRAINTS"
+    columns = [
+        "CONSTRAINT_CATALOG",
+        "CONSTRAINT_SCHEMA",
+        "CONSTRAINT_NAME",
+        "TABLE_SCHEMA",
+        "TABLE_NAME",
+        "CONSTRAINT_TYPE",
+        "ENFORCED",
+    ]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, tables = _get_scope(query)
+
+        records = _get_records_from_data_catalog(databases, tables)
+
+        data = []
+        for record in records:
+            database_name = record.integration.name
+            table_name = record.name
+            primary_keys = record.meta_primary_keys
+            foreign_keys_children = record.meta_foreign_keys_children
+            foreign_keys_parents = record.meta_foreign_keys_parents
+
+            for pk in primary_keys:
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": pk.constraint_name,
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "CONSTRAINT_TYPE": "PRIMARY KEY",
+                }
+                data.append(item)
+
+            for fk in foreign_keys_children:
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": fk.constraint_name,
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "CONSTRAINT_TYPE": "FOREIGN KEY",
+                }
+                data.append(item)
+
+            for fk in foreign_keys_parents:
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": fk.constraint_name,
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "CONSTRAINT_TYPE": "FOREIGN KEY",
+                }
+                data.append(item)
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+class MetaColumnUsageTable(Table):
+    name = "META_KEY_COLUMN_USAGE"
+    columns = [
+        "CONSTRAINT_CATALOG",
+        "CONSTRAINT_SCHEMA",
+        "CONSTRAINT_NAME",
+        "TABLE_CATALOG",
+        "TABLE_SCHEMA",
+        "TABLE_NAME",
+        "COLUMN_NAME",
+        "ORDINAL_POSITION",
+        "POSITION_IN_UNIQUE_CONSTRAINT",
+        "REFERENCED_TABLE_SCHEMA",
+        "REFERENCED_TABLE_NAME",
+        "REFERENCED_COLUMN_NAME",
+    ]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, tables = _get_scope(query)
+
+        records = _get_records_from_data_catalog(databases, tables)
+
+        data = []
+        for record in records:
+            database_name = record.integration.name
+            table_name = record.name
+            primary_keys = record.meta_primary_keys
+            foreign_keys_children = record.meta_foreign_keys_children
+            foreign_keys_parents = record.meta_foreign_keys_parents
+
+            for pk in primary_keys:
+                column = pk.meta_columns
+
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": pk.constraint_name,
+                    "TABLE_CATALOG": "def",
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "COLUMN_NAME": column.name,
+                    "ORDINAL_POSITION": pk.ordinal_position,
+                    "POSITION_IN_UNIQUE_CONSTRAINT": None,
+                    "REFERENCED_TABLE_SCHEMA": None,
+                    "REFERENCED_TABLE_NAME": None,
+                    "REFERENCED_COLUMN_NAME": None,
+                }
+                data.append(item)
+
+            for fk in foreign_keys_children:
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": fk.constraint_name,
+                    "TABLE_CATALOG": "def",
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "COLUMN_NAME": fk.child_column.name,
+                    "ORDINAL_POSITION": None,
+                    "POSITION_IN_UNIQUE_CONSTRAINT": None,
+                    "REFERENCED_TABLE_SCHEMA": fk.parent_table.integration.name if fk.parent_table else None,
+                    "REFERENCED_TABLE_NAME": fk.parent_table.name if fk.parent_table else None,
+                    "REFERENCED_COLUMN_NAME": fk.parent_column.name if fk.parent_column else None,
+                }
+                data.append(item)
+
+            for fk in foreign_keys_parents:
+                item = {
+                    "CONSTRAINT_CATALOG": "def",
+                    "CONSTRAINT_SCHEMA": database_name,
+                    "CONSTRAINT_NAME": fk.constraint_name,
+                    "TABLE_CATALOG": "def",
+                    "TABLE_SCHEMA": database_name,
+                    "TABLE_NAME": table_name,
+                    "COLUMN_NAME": fk.child_column.name,
+                    "ORDINAL_POSITION": None,
+                    "POSITION_IN_UNIQUE_CONSTRAINT": None,
+                    "REFERENCED_TABLE_SCHEMA": fk.child_table.integration.name if fk.child_table else None,
+                    "REFERENCED_TABLE_NAME": fk.child_table.name if fk.child_table else None,
+                    "REFERENCED_COLUMN_NAME": fk.parent_column.name if fk.child_column else None,
+                }
+                data.append(item)
+
+        df = pd.DataFrame(data, columns=cls.columns)
+        return df
+
+
+class MetaHandlerInfoTable(Table):
+    name = "META_HANDLER_INFO"
+    columns = ["HANDLER_INFO", "TABLE_SCHEMA"]
+
+    @classmethod
+    def get_data(cls, query: ASTNode = None, inf_schema=None, **kwargs):
+        databases, tables = _get_scope(query)
+
+        data = []
+        for database in databases:
+            data_catalog_reader = DataCatalogReader(database_name=database, table_names=tables)
+            handler_info = data_catalog_reader.get_handler_info()
+            data.append({"HANDLER_INFO": str(handler_info), "TABLE_SCHEMA": database})
 
         df = pd.DataFrame(data, columns=cls.columns)
         return df

--- a/mindsdb/integrations/handlers/lindorm_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/lindorm_handler/requirements.txt
@@ -1,3 +1,3 @@
 pyphoenix
 phoenixdb
-protobuf==3.20.3
+protobuf==4.25.8

--- a/mindsdb/integrations/handlers/ludwig_handler/requirements.txt
+++ b/mindsdb/integrations/handlers/ludwig_handler/requirements.txt
@@ -1,3 +1,3 @@
 ludwig[distributed]>=0.5.2
-ray==2.8.1
+ray==2.43.0
 dask

--- a/mindsdb/interfaces/agents/constants.py
+++ b/mindsdb/interfaces/agents/constants.py
@@ -171,6 +171,8 @@ NVIDIA_NIM_CHAT_MODELS = (
 )
 
 GOOGLE_GEMINI_CHAT_MODELS = (
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
     "gemini-2.5-pro-preview-03-25",
     "gemini-2.0-flash",
     "gemini-2.0-flash-lite",

--- a/mindsdb/interfaces/agents/mindsdb_database_agent.py
+++ b/mindsdb/interfaces/agents/mindsdb_database_agent.py
@@ -111,24 +111,12 @@ class MindsDBSQL(SQLDatabase):
             )
 
             # Convert ExecuteAnswer to a DataFrame for easier manipulation
-            df = None
-            if hasattr(result, "data") and hasattr(result.data, "data_frame"):
-                df = result.data.data_frame
+            if result.data is not None:
+                df = result.data.to_df()
+                return df.to_string(index=False)
+
             else:
-                # Fallback to to_df when data_frame attr not available
-                try:
-                    df = result.data.to_df()
-                except Exception:
-                    df = None
-
-            # Default behaviour (string)
-            if df is not None:
-                if not df.empty:
-                    return df.to_string(index=False)
-                else:
-                    return "Query executed successfully, but returned no data."
-
-            return str(result)
+                return "Query executed successfully, but returned no data."
 
         except Exception as e:
             logger.error(f"Error executing SQL command: {str(e)}\n{traceback.format_exc()}")

--- a/mindsdb/interfaces/data_catalog/data_catalog_reader.py
+++ b/mindsdb/interfaces/data_catalog/data_catalog_reader.py
@@ -11,8 +11,6 @@ class DataCatalogReader(BaseDataCatalog):
         """
         Read the metadata from the data catalog and return it as a string.
         """
-        if not self.is_data_catalog_supported():
-            return f"Data catalog is not supported for database '{self.database_name}'."
         tables = self._read_metadata()
         if not tables:
             self.logger.warning(f"No metadata found for database '{self.database_name}'")
@@ -26,10 +24,29 @@ class DataCatalogReader(BaseDataCatalog):
             metadata_str += table.as_string() + "\n\n"
         return metadata_str
 
+    def read_metadata_as_records(self) -> list:
+        """
+        Read the metadata from the data catalog and return it as a list of database records.
+        """
+        tables = self._read_metadata()
+        if not tables:
+            self.logger.warning(f"No metadata found for database '{self.database_name}'")
+            return []
+        return tables
+
+    def get_handler_info(self) -> str:
+        """
+        Get the handler info for the database.
+        """
+        return self.data_handler.meta_get_handler_info()
+
     def _read_metadata(self) -> list:
         """
         Read the metadata from the data catalog and return it in a structured format.
         """
+        if not self.is_data_catalog_supported():
+            return f"Data catalog is not supported for database '{self.database_name}'."
+
         query = db.session.query(db.MetaTables).filter_by(integration_id=self.integration_id)
         if self.table_names:
             cleaned_table_names = [name.strip("`").split(".")[-1] for name in self.table_names]

--- a/mindsdb/interfaces/knowledge_base/controller.py
+++ b/mindsdb/interfaces/knowledge_base/controller.py
@@ -52,6 +52,13 @@ def get_model_params(model_params: dict, default_config_key: str):
     """
     Get model parameters by combining default config with user provided parameters.
     """
+    # If the default config key is for reranking and the switch to use the default LLM is enabled,
+    # switch to the default LLM model.
+    if default_config_key == "default_reranking_model" and config.get("default_reranking_model").get(
+        "use_default_llm", False
+    ):
+        default_config_key = "default_llm_model"
+
     combined_model_params = copy.deepcopy(config.get(default_config_key, {}))
 
     if model_params:
@@ -96,6 +103,8 @@ def get_reranking_model_from_params(reranking_model_params: dict):
     if "api_key" not in params_copy:
         params_copy["api_key"] = get_api_key(provider, params_copy, strict=False)
     params_copy["model"] = params_copy.pop("model_name", None)
+
+    params_copy.pop("use_default_llm", None)
 
     return BaseLLMReranker(**params_copy)
 

--- a/mindsdb/interfaces/knowledge_base/preprocessing/document_loader.py
+++ b/mindsdb/interfaces/knowledge_base/preprocessing/document_loader.py
@@ -2,7 +2,6 @@ import os
 from typing import List, Iterator
 from langchain_core.documents import Document as LangchainDocument
 from langchain_text_splitters import MarkdownHeaderTextSplitter
-import pandas as pd
 
 from mindsdb.interfaces.file.file_controller import FileController
 from mindsdb.integrations.utilities.rag.loaders.file_loader import FileLoader
@@ -20,12 +19,12 @@ class DocumentLoader:
     """Handles loading documents from various sources including SQL queries"""
 
     def __init__(
-            self,
-            file_controller: FileController,
-            file_splitter: FileSplitter,
-            markdown_splitter: MarkdownHeaderTextSplitter,
-            file_loader_class=FileLoader,
-            mysql_proxy=None
+        self,
+        file_controller: FileController,
+        file_splitter: FileSplitter,
+        markdown_splitter: MarkdownHeaderTextSplitter,
+        file_loader_class=FileLoader,
+        mysql_proxy=None,
     ):
         """
         Initialize with required dependencies
@@ -52,8 +51,8 @@ class DocumentLoader:
             for doc in loader.lazy_load():
                 # Add file extension to metadata for proper splitting
                 extension = os.path.splitext(file_path)[1].lower()
-                doc.metadata['extension'] = extension
-                doc.metadata['source'] = file_name
+                doc.metadata["extension"] = extension
+                doc.metadata["source"] = file_name
 
                 # Use FileSplitter to handle the document based on its type
                 split_docs = self.file_splitter.split_documents([doc])
@@ -62,34 +61,22 @@ class DocumentLoader:
                     metadata = doc.metadata.copy()
                     metadata.update(split_doc.metadata or {})
 
-                    yield Document(
-                        content=split_doc.page_content,
-                        metadata=metadata
-                    )
+                    yield Document(content=split_doc.page_content, metadata=metadata)
 
     def load_web_pages(
-            self,
-            urls: List[str],
-            crawl_depth: int,
-            limit: int,
-            filters: List[str] = None,
+        self,
+        urls: List[str],
+        crawl_depth: int,
+        limit: int,
+        filters: List[str] = None,
     ) -> Iterator[Document]:
         """Load and split documents from web pages"""
-        websites_df = get_all_websites(
-            urls,
-            crawl_depth=crawl_depth,
-            limit=limit,
-            filters=filters
-        )
+        websites_df = get_all_websites(urls, crawl_depth=crawl_depth, limit=limit, filters=filters)
 
         for _, row in websites_df.iterrows():
             # Create a document with HTML extension for proper splitting
             doc = LangchainDocument(
-                page_content=row['text_content'],
-                metadata={
-                    'extension': '.html',
-                    'url': row['url']
-                }
+                page_content=row["text_content"], metadata={"extension": ".html", "url": row["url"]}
             )
 
             # Use FileSplitter to handle HTML content
@@ -98,60 +85,4 @@ class DocumentLoader:
                 metadata = doc.metadata.copy()
                 metadata.update(split_doc.metadata or {})
 
-                yield Document(
-                    content=split_doc.page_content,
-                    metadata=metadata
-                )
-
-    def load_query_result(self, query: str, project_name: str) -> Iterator[Document]:
-        """
-        Load documents from SQL query results
-
-        Args:
-            query: SQL query to execute
-            project_name: Name of the project context
-
-        Returns:
-            Iterator of Document objects
-
-        Raises:
-            ValueError: If mysql_proxy is not configured or query returns no data
-        """
-        if not self.mysql_proxy:
-            raise ValueError("MySQL proxy not configured")
-
-        if not query:
-            return
-
-        # Set project context and execute query
-        self.mysql_proxy.set_context({'db': project_name})
-        query_result = self.mysql_proxy.process_query(query)
-
-        if query_result.type != 'table':
-            raise ValueError('Query returned no data')
-
-        # Convert query result to DataFrame
-        df = query_result.data.to_df()
-
-        # Process each row into a Document
-        for _, row in df.iterrows():
-            # Extract id, content  and metadata
-            content = str(row.get('content', ''))
-            id = row.get('id', None)
-
-            # Convert remaining columns to metadata
-            metadata = {
-                col: str(row[col])
-                for col in df.columns
-                if col != 'content' and not pd.isna(row[col])
-            }
-            metadata['source'] = 'query'
-
-            # Split content using recursive splitter
-            if content:
-
-                yield Document(
-                    id=id,
-                    content=content,
-                    metadata=metadata
-                )
+                yield Document(content=split_doc.page_content, metadata=metadata)

--- a/mindsdb/interfaces/skills/custom/text2sql/mindsdb_kb_tools.py
+++ b/mindsdb/interfaces/skills/custom/text2sql/mindsdb_kb_tools.py
@@ -6,6 +6,27 @@ from langchain_core.tools import BaseTool
 from mindsdb_sql_parser.ast import Describe, Select, Identifier, Constant, Star
 
 
+def llm_str_strip(s):
+    length = -1
+    while length != len(s):
+        length = len(s)
+
+        # remove ```
+        if s.startswith("```"):
+            s = s[3:]
+        if s.endswith("```"):
+            s = s[:-3]
+
+        # remove trailing new lines
+        s = s.strip("\n")
+
+        # remove extra quotes
+        for q in ('"', "'", "`"):
+            if s.count(q) == 1:
+                s = s.strip(q)
+    return s
+
+
 class KnowledgeBaseListToolInput(BaseModel):
     tool_input: str = Field("", description="An empty string to list all knowledge bases.")
 
@@ -56,26 +77,6 @@ class KnowledgeBaseInfoTool(BaseTool):
         except (json.JSONDecodeError, TypeError):
             pass
 
-        def strip(s):
-            length = -1
-            while length != len(s):
-                length = len(s)
-
-                # remove ```
-                if s.startswith("```"):
-                    s = s[3:]
-                if s.endswith("```"):
-                    s = s[:-3]
-
-                # remove trailing new lines
-                s = s.strip("\n")
-
-                # remove extra quotes
-                for q in ('"', "'", "`"):
-                    if s.count(q) == 1:
-                        s = s.strip(q)
-            return s
-
         # Finally, try the original regex pattern for $START$ and $STOP$ markers
         match = re.search(r"\$START\$(.*?)\$STOP\$", tool_input, re.DOTALL)
         if not match:
@@ -84,14 +85,14 @@ class KnowledgeBaseInfoTool(BaseTool):
                 return [kb.strip() for kb in tool_input.split(",")]
             # If it's just a single string without formatting, return it as a single item
             if tool_input.strip():
-                return [strip(tool_input)]
+                return [llm_str_strip(tool_input)]
             return []
 
         # Extract and clean the knowledge base names
         kb_names_str = match.group(1).strip()
         kb_names = re.findall(r"`([^`]+)`", kb_names_str)
 
-        kb_names = [strip(n) for n in kb_names]
+        kb_names = [llm_str_strip(n) for n in kb_names]
         return kb_names
 
     def _run(self, tool_input: str) -> str:
@@ -221,6 +222,7 @@ class KnowledgeBaseQueryTool(BaseTool):
 
         try:
             # Execute the query
+            query = llm_str_strip(query)
             result = self.db.run_no_throw(query)
 
             if not result:

--- a/mindsdb/interfaces/skills/sql_agent.py
+++ b/mindsdb/interfaces/skills/sql_agent.py
@@ -76,7 +76,7 @@ def split_table_name(table_name: str) -> List[str]:
         result.append(current.strip("`"))
 
     # ensure we split the table name
-    result = [r.split(".") for r in result][0]
+    # result = [r.split(".") for r in result][0]
 
     return result
 

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,6 +1,6 @@
 pre-commit>=2.16.0
 watchfiles==0.19.0
-setuptools==75.8.2
+setuptools==78.1.1
 wheel
 deptry==0.20.0
 twine

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -20,7 +20,7 @@ mindsdb-sql-parser ~= 0.10.0
 pydantic == 2.9.2
 mindsdb-evaluator == 0.0.17
 duckdb ~= 1.2.1
-requests == 2.32.3
+requests == 2.32.4
 dateparser==1.2.0
 dill == 0.3.6
 numpy

--- a/tests/unused/unit/api/http/knowledge_bases_test.py
+++ b/tests/unused/unit/api/http/knowledge_bases_test.py
@@ -950,24 +950,20 @@ def test_document_loader_sql_error_handling(client):
     create_response = client.post('/api/projects/mindsdb/knowledge_bases', json=create_request, follow_redirects=True)
     assert create_response.status_code == HTTPStatus.CREATED
 
+    # This will not use the document loader.
     update_request = {
         'knowledge_base': {
             'query': 'INVALID SQL QUERY'
         }
     }
 
-    with patch('mindsdb.interfaces.knowledge_base.preprocessing.document_loader.DocumentLoader') as mock_loader_class:
-        mock_loader = MagicMock()
-        mock_loader_class.return_value = mock_loader
-        mock_loader.load_query_result.side_effect = ValueError('Invalid SQL query')
+    update_response = client.put(
+        '/api/projects/mindsdb/knowledge_bases/test_kb_sql_errors',
+        json=update_request,
+        follow_redirects=True
+    )
 
-        update_response = client.put(
-            '/api/projects/mindsdb/knowledge_bases/test_kb_sql_errors',
-            json=update_request,
-            follow_redirects=True
-        )
-
-        assert update_response.status_code == HTTPStatus.BAD_REQUEST
+    assert update_response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_preprocessing_update(client):


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `7cbcffc..621c0c7`
**Files Changed:** 19 (13 programming files)
**Programming Ratio:** 68.4%

**Commits included:**
- Fix agent with KB:  strip input of kb_query_tool (#11136)
- Add Support for Stable Gemini 2.5 Models (#11117)
- Bump brace-expansion from 1.1.11 to 1.1.12 in /docs (#11072)
- Bump ray from 2.8.1 to 2.43.0 in /mindsdb/integrations/handlers/ludwig_handler (#10543)
- Exposed the Data Catalog as Part of MindsDB's Information Schema (#11087)
- Release (#11128)
- Bump setuptools from 75.8.2 to 78.1.1 in /requirements (#10991)
- Fixed Knowledge Base Insert Operations via SQL Queries and Raw Data (#11127)
- Replace `locals()` to `connection.register` when register duckdb tables (#11099)
- Added the Option to Use Default LLM as the Default Re-ranking Model (#11119)
... and 5 more commits